### PR TITLE
max var value that work on most Stata

### DIFF
--- a/Presentations/Lab 2 - Coding for Reproducible Research.Rmd
+++ b/Presentations/Lab 2 - Coding for Reproducible Research.Rmd
@@ -159,7 +159,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ```{stata, eval = F}
     clear
-    set maxvar 120000
+    set maxvar 30000
     set more off
 ```
 


### PR DESCRIPTION
If participants does not have the most recent version of Stata this code will not work if they were to test it if the value is that high. I think 30000 is better to avoid confusion